### PR TITLE
Update git config files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,62 @@
+#######################################
+#            Core Options             #
+#######################################
+
+# This file is the top-most EditorConfig file
+root = true
+
+# All Files
+[*]
+charset = utf-8
+guidelines = 120
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+#######################################
+#       File Extension Settings       #
+#######################################
+
+# Markdown
+[*.{md,mdx}]
+trim_trailing_whitespace = false
+
+# JSON
+[*.{json,json5,webmanifest}]
+indent_size = 2
+
+# YAML
+[*.{yml,yaml,clang-format,clang-tidy}]
+indent_size = 2
+
+# CMake
+[{CMakeLists.txt,*.cmake,*.rst}]
+indent_size = 2
+indent_style = space
+
+# Makefile
+[Makefile]
+end_of_line = lf
+indent_style = tab
+
+# Visual Studio Solution
+[*.sln]
+indent_style = tab
+
+# C/C++
+[*.{c++,c,cc,cpp,cppm,cxx,h,h++,hh,hpp,hxx,inl,ipp,ixx,tlh,tli}]
+end_of_line = lf
+
+# C#
+[*.cs]
+end_of_line = crlf
+csharp_prefer_braces = true
+
+# Pawn
+[*.{inc,sma,sp}]
+end_of_line = lf
+
+# Python
+[*.{py,py3}]
+guidelines = 88

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,224 @@
+##############
+#   Common   #
+##############
+
+# Auto detect text files and perform LF normalization
+*                       text=auto
+
+# Archives
+*.7z                    binary
+*.bz                    binary
+*.bz2                   binary
+*.bzip2                 binary
+*.gz                    binary
+*.lz                    binary
+*.lzma                  binary
+*.rar                   binary
+*.tar                   binary
+*.taz                   binary
+*.tbz                   binary
+*.tbz2                  binary
+*.tgz                   binary
+*.tlz                   binary
+*.txz                   binary
+*.xz                    binary
+*.Z                     binary
+*.zip                   binary
+*.zst                   binary
+
+# Audio
+*.kar                   binary
+*.m4a                   binary
+*.mid                   binary
+*.midi                  binary
+*.mp3                   binary
+*.ogg                   binary
+*.ra                    binary
+
+# Documents
+*.adoc                  text
+*.bibtex                text diff=bibtex
+*.csv                   text eol=crlf
+*.doc                   diff=astextplain
+*.DOC                   diff=astextplain
+*.docx                  diff=astextplain
+*.DOCX                  diff=astextplain
+*.dot                   diff=astextplain
+*.DOT                   diff=astextplain
+*.epub                  diff=astextplain
+*.md                    text diff=markdown
+*.mdx                   text diff=markdown
+*.mustache              text
+*.pdf                   diff=astextplain
+*.PDF                   diff=astextplain
+*.rtf                   diff=astextplain
+*.RTF                   diff=astextplain
+*.sql                   text
+*.tab                   text
+*.tex                   text diff=tex
+*.textile               text
+*.tsv                   text
+*.txt                   text
+
+# Fonts
+*.eot                   binary
+*.otf                   binary
+*.ttf                   binary
+*.woff                  binary
+*.woff2                 binary
+
+# Graphics
+*.ai                    binary
+*.bmp                   binary
+*.eps                   binary
+*.gif                   binary
+*.gifv                  binary
+*.ico                   binary
+*.jng                   binary
+*.jp2                   binary
+*.jpeg                  binary
+*.jpg                   binary
+*.jpx                   binary
+*.jxr                   binary
+*.png                   binary
+*.psb                   binary
+*.psd                   binary
+*.svg                   binary
+*.svgz                  binary
+*.tif                   binary
+*.tiff                  binary
+*.wbmp                  binary
+*.webp                  binary
+
+# Scripts
+*.bash                  text eol=lf
+*.bat                   text eol=crlf
+*.cmd                   text eol=crlf
+*.fish                  text eol=lf
+*.ksh                   text eol=lf
+*.sh                    text eol=lf
+*.zsh                   text eol=lf
+
+# Video
+*.3gp                   binary
+*.3gpp                  binary
+*.as                    binary
+*.asf                   binary
+*.asx                   binary
+*.avi                   binary
+*.fla                   binary
+*.flv                   binary
+*.m4v                   binary
+*.mng                   binary
+*.mov                   binary
+*.mp4                   binary
+*.mpeg                  binary
+*.mpg                   binary
+*.ogv                   binary
+*.swc                   binary
+*.swf                   binary
+*.webm                  binary
+
+# Text files where line endings should be preserved
+*.patch                 -text
+
+#############
+#   C/C++   #
+#############
+
+# Sources
+*.c                     text eol=lf diff=cpp
+*.c++                   text eol=lf diff=cpp
+*.cc                    text eol=lf diff=cpp
+*.cpi                   text eol=lf diff=cpp
+*.cpp                   text eol=lf diff=cpp
+*.cxx                   text eol=lf diff=cpp
+*.h                     text eol=lf diff=cpp
+*.h++                   text eol=lf diff=cpp
+*.hh                    text eol=lf diff=cpp
+*.hpp                   text eol=lf diff=cpp
+
+# Compiled Object files
+*.lo                    binary
+*.o                     binary
+*.obj                   binary
+*.slo                   binary
+
+# Precompiled Headers
+*.gch                   binary
+*.pch                   binary
+
+# Compiled Dynamic libraries
+*.dll                   binary
+*.dylib                 binary
+*.so                    binary
+
+# Compiled Static libraries
+*.a                     binary
+*.la                    binary
+*.lai                   binary
+*.lib                   binary
+
+# Executables
+*.app                   binary
+*.exe                   binary
+*.out                   binary
+
+#############
+#   CMake   #
+#############
+
+*.cmake                 eol=lf
+CMakeLists.txt          eol=lf
+CMakePresets.json       eol=lf
+CMakeUserPresets.json   eol=lf
+
+####################
+#   EditorConfig   #
+####################
+
+.editorconfig           eol=lf
+
+###########
+#   Git   #
+###########
+
+.gitattributes          eol=lf
+.gitignore              eol=lf
+
+######################
+#   MicrosoftShell   #
+######################
+
+# Source files
+*.mcf                   text eol=crlf
+*.msh                   text eol=crlf
+*.msh1                  text eol=crlf
+*.msh1xml               text eol=crlf
+*.msh2                  text eol=crlf
+*.msh2xml               text eol=crlf
+*.mshxml                text eol=crlf
+
+############
+#   Pawn   #
+############
+
+*.inc                   eol=lf
+*.inl                   eol=lf
+*.sma                   eol=lf
+*.sp                    eol=lf
+*.vault                 binary
+
+##################
+#   PowerShell   #
+##################
+
+# Source files
+*.cdxml                 text eol=crlf
+*.ps1                   text eol=crlf
+*.ps1x                  text eol=crlf
+*.ps1xml                text eol=crlf
+*.psd1                  text eol=crlf
+*.psm1                  text eol=crlf
+*.psrc                  text eol=crlf
+*.pssc                  text eol=crlf

--- a/.gitignore
+++ b/.gitignore
@@ -1,23 +1,692 @@
+#########################
+#  Auto-generated Files #
+#########################
+
+**/appversion.h
+
+#########################
+#   Build Directories   #
+#########################
+
 **/build
+
+#########
+#   C   #
+#########
+
+# Debug files
+*.dSYM/
+*.idb
+*.pdb
+*.su
+
+# Executables
+*.app
+*.exe
+*.hex
+*.i*86
+*.out
+*.x86_64
+
+# Kernel Module Compile Results
+.tmp_versions/
+#*.cmd
+*.mod*
+dkms.conf
+Mkfile.old
+Module.symvers
+modules.order
+
+# Libraries
+*.a
+*.la
+*.lib
+*.lo
+
+# Linker output
+*.exp
+*.ilk
+*.map
+
+# Object files
+*.elf
+*.ko
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Prerequisites
+*.d
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.dylib
+*.so
+*.so.*
+
+###########
+#   C++   #
+###########
+
+# Compiled Object files
+*.slo
+
+# Compiled Static libraries
+*.lai
+
+# Fortran module files
+*.mod
+*.smod
+
+#############
+#   CMake   #
+#############
+
+_deps
+cmake_install.cmake
+CMakeCache.txt
+CMakeFiles
+CMakeLists.txt.user
+CMakeScripts
+compile_commands.json
+CTestTestfile.cmake
+install_manifest.txt
+Makefile
+Testing
+
+# External projects
+*-prefix/
+
+#############
+#   Gradle  #
+#############
+
 **/.gradle
-.idea
-*.iml
-*.bat
-**/msvc/Debug*
-**/msvc/Release*
-**/msvc/.vs
-**/msvc/*.db
-**/msvc/*.opendb
-**/msvc/*.sdf
-**/msvc/*.opensdf
-**/msvc/*.user
-**/msvc/*.suo
-**/msvc/*.db
-**/msvc/*.opendb
-**/msvc/*.aps
-**/msvc/ipch
-**/PublishPath*.txt
-**/*.log
+
+############
+#   .NET   #
+############
+
+# Common node modules locations
+/node_modules
+/wwwroot/node_modules
+
+############
+#   Gcov   #
+############
+
+# gcc coverage testing tool files
+*.gcda
+*.gcno
+*.gcov
+
+#################
+#   JetBrains   #
+#################
+
+# Ignore all files and directories under .idea/
+.idea/
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+# *.iml
+# modules.xml
+# .idea/misc.xml
+# *.ipr
+
+# Sonarlint plugin
+.idea/**/sonarlint/
+
+# SonarQube Plugin
+.idea/**/sonarIssues.xml
+
+# Markdown Navigator plugin
+.idea/**/markdown-navigator.xml
+.idea/**/markdown-navigator-enh.xml
+.idea/**/markdown-navigator/
+
+# Cache file creation bug
+.idea/$CACHE_FILE$
+
+# CodeStream plugin
+.idea/codestream.xml
+
+# Azure Toolkit for IntelliJ plugin
+.idea/**/azureSettings.xml
+
+############
+#   Pawn   #
+############
+
+# Compiled Bytecode, precompiled output and assembly
+*.amx
+*.amxx
+
+# Dependency versions lockfile
+pawn.lock
+
+####################
+#    Publishing    #
+####################
 
 publish
-**/appversion.h
+**/PublishPath*.txt
+
+#################
+#   SonarQube   #
+#################
+
+# Sonar Scanner working directories
+.scannerwork/
+.sonar/
+.sonarqube/
+
+# SonarLint working directories, configuration files (including credentials)
+.sonarlint/
+
+##################
+#   SourcePawn   #
+##################
+
+*.smx
+
+#############
+#   vcpkg   #
+#############
+
+vcpkg_installed/
+vcpkg-manifest-install.log
+
+########################
+#   VisualStudioCode   #
+########################
+
+.vscode/*
+!.vscode/*.code-snippets
+!.vscode/extensions.json
+!.vscode/launch.json
+!.vscode/settings.json
+!.vscode/tasks.json
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+# Ignore all local history of files
+.history
+.ionide
+
+#####################
+#   Visual Studio   #
+#####################
+
+# User-specific files
+*.rsuser
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+
+# User-specific files (MonoDevelop/Xamarin Studio)
+*.userprefs
+
+# Mono auto generated files
+mono_crash.*
+
+# Build results
+[Dd]ebug/
+[Dd]ebugPublic/
+[Rr]elease/
+[Rr]eleases/
+x64/
+x86/
+[Ww][Ii][Nn]32/
+[Aa][Rr][Mm]/
+[Aa][Rr][Mm]64/
+bld/
+[Bb]in/
+[Oo]bj/
+[Ll]og/
+[Ll]ogs/
+
+# Visual Studio 2015/2017 cache/options directory
+.vs/
+# Uncomment if you have tasks that create the project's static files in wwwroot
+#wwwroot/
+
+# Visual Studio 2017 auto generated files
+Generated\ Files/
+
+# MSTest test Results
+[Tt]est[Rr]esult*/
+[Bb]uild[Ll]og.*
+
+# NUnit
+*.VisualState.xml
+TestResult.xml
+nunit-*.xml
+
+# Build Results of an ATL Project
+[Dd]ebugPS/
+[Rr]eleasePS/
+dlldata.c
+
+# Benchmark Results
+BenchmarkDotNet.Artifacts/
+
+# .NET Core
+project.lock.json
+project.fragment.lock.json
+artifacts/
+
+# ASP.NET Scaffolding
+ScaffoldingReadMe.txt
+
+# StyleCop
+StyleCopReport.xml
+
+# Files built by Visual Studio
+*_i.c
+*_p.c
+*_h.h
+*.meta
+*.iobj
+*.ipdb
+*.pgc
+*.pgd
+*.rsp
+# but not Directory.Build.rsp, as it configures directory-level build defaults
+!Directory.Build.rsp
+*.sbr
+*.tlb
+*.tli
+*.tlh
+*.tmp
+*.tmp_proj
+*_wpftmp.csproj
+*.log
+*.tlog
+*.vspscc
+*.vssscc
+.builds
+*.pidb
+*.svclog
+*.scc
+
+# Chutzpah Test files
+_Chutzpah*
+
+# Visual C++ cache files
+ipch/
+*.aps
+*.ncb
+*.opendb
+*.opensdf
+*.sdf
+*.cachefile
+*.VC.db
+*.VC.VC.opendb
+
+# Visual Studio profiler
+*.psess
+*.vsp
+*.vspx
+*.sap
+
+# Visual Studio Trace Files
+*.e2e
+
+# TFS 2012 Local Workspace
+$tf/
+
+# Guidance Automation Toolkit
+*.gpState
+
+# ReSharper is a .NET coding add-in
+_ReSharper*/
+*.[Rr]e[Ss]harper
+*.DotSettings.user
+
+# TeamCity is a build add-in
+_TeamCity*
+
+# DotCover is a Code Coverage Tool
+*.dotCover
+
+# AxoCover is a Code Coverage Tool
+.axoCover/*
+!.axoCover/settings.json
+
+# Coverlet is a free, cross platform Code Coverage Tool
+coverage*.json
+coverage*.xml
+coverage*.info
+
+# Visual Studio code coverage results
+*.coverage
+*.coveragexml
+
+# NCrunch
+_NCrunch_*
+.*crunch*.local.xml
+nCrunchTemp_*
+
+# MightyMoose
+*.mm.*
+AutoTest.Net/
+
+# Web workbench (sass)
+.sass-cache/
+
+# Installshield output folder
+[Ee]xpress/
+
+# DocProject is a documentation generator add-in
+DocProject/buildhelp/
+DocProject/Help/*.HxT
+DocProject/Help/*.HxC
+DocProject/Help/*.hhc
+DocProject/Help/*.hhk
+DocProject/Help/*.hhp
+DocProject/Help/Html2
+DocProject/Help/html
+
+# Click-Once directory
+publish/
+
+# Publish Web Output
+*.[Pp]ublish.xml
+*.azurePubxml
+# Note: Comment the next line if you want to checkin your web deploy settings,
+# but database connection strings (with potential passwords) will be unencrypted
+*.pubxml
+*.publishproj
+
+# Microsoft Azure Web App publish settings. Comment the next line if you want to
+# checkin your Azure Web App publish settings, but sensitive information contained
+# in these scripts will be unencrypted
+PublishScripts/
+
+# NuGet Packages
+*.nupkg
+# NuGet Symbol Packages
+*.snupkg
+# The packages folder can be ignored because of Package Restore
+**/[Pp]ackages/*
+.nuget/
+# except build/, which is used as an MSBuild target.
+!**/[Pp]ackages/build/
+# Uncomment if necessary however generally it will be regenerated when needed
+#!**/[Pp]ackages/repositories.config
+# NuGet v3's project.json files produces more ignorable files
+*.nuget.props
+*.nuget.targets
+
+# Microsoft Azure Build Output
+csx/
+*.build.csdef
+
+# Microsoft Azure Emulator
+ecf/
+rcf/
+
+# Windows Store app package directories and files
+AppPackages/
+BundleArtifacts/
+Package.StoreAssociation.xml
+_pkginfo.txt
+*.appx
+*.appxbundle
+*.appxupload
+
+# Visual Studio cache files
+# files ending in .cache can be ignored
+*.[Cc]ache
+# but keep track of directories ending in .cache
+!?*.[Cc]ache/
+
+# Others
+ClientBin/
+~$*
+*~
+*.dbmdl
+*.dbproj.schemaview
+*.jfm
+*.pfx
+*.publishsettings
+orleans.codegen.cs
+
+# Including strong name files can present a security risk
+# (https://github.com/github/gitignore/pull/2483#issue-259490424)
+#*.snk
+
+# Since there are multiple workflows, uncomment next line to ignore bower_components
+# (https://github.com/github/gitignore/pull/1529#issuecomment-104372622)
+#bower_components/
+
+# RIA/Silverlight projects
+Generated_Code/
+
+# Backup & report files from converting an old project file
+# to a newer Visual Studio version. Backup files are not needed,
+# because we have git ;-)
+_UpgradeReport_Files/
+Backup*/
+UpgradeLog*.XML
+UpgradeLog*.htm
+ServiceFabricBackup/
+*.rptproj.bak
+
+# SQL Server files
+*.mdf
+*.ldf
+*.ndf
+
+# Business Intelligence projects
+*.rdl.data
+*.bim.layout
+*.bim_*.settings
+*.rptproj.rsuser
+*- [Bb]ackup.rdl
+*- [Bb]ackup ([0-9]).rdl
+*- [Bb]ackup ([0-9][0-9]).rdl
+
+# Microsoft Fakes
+FakesAssemblies/
+
+# GhostDoc plugin setting file
+*.GhostDoc.xml
+
+# Node.js Tools for Visual Studio
+.ntvs_analysis.dat
+node_modules/
+
+# Visual Studio 6 build log
+*.plg
+
+# Visual Studio 6 workspace options file
+*.opt
+
+# Visual Studio 6 auto-generated workspace file (contains which files were open etc.)
+*.vbw
+
+# Visual Studio 6 auto-generated project file (contains which files were open etc.)
+*.vbp
+
+# Visual Studio 6 workspace and project file (working project files containing files to include in project)
+*.dsw
+*.dsp
+
+# Visual Studio 6 technical files
+*.ncb
+*.aps
+
+# Visual Studio LightSwitch build output
+**/*.HTMLClient/GeneratedArtifacts
+**/*.DesktopClient/GeneratedArtifacts
+**/*.DesktopClient/ModelManifest.xml
+**/*.Server/GeneratedArtifacts
+**/*.Server/ModelManifest.xml
+_Pvt_Extensions
+
+# Paket dependency manager
+.paket/paket.exe
+paket-files/
+
+# FAKE - F# Make
+.fake/
+
+# CodeRush personal settings
+.cr/personal
+
+# Python Tools for Visual Studio (PTVS)
+__pycache__/
+*.pyc
+
+# Cake - Uncomment if you are using it
+# tools/**
+# !tools/packages.config
+
+# Tabs Studio
+*.tss
+
+# Telerik's JustMock configuration file
+*.jmconfig
+
+# BizTalk build output
+*.btp.cs
+*.btm.cs
+*.odx.cs
+*.xsd.cs
+
+# OpenCover UI analysis results
+OpenCover/
+
+# Azure Stream Analytics local run output
+ASALocalRun/
+
+# MSBuild Binary and Structured Log
+*.binlog
+
+# NVidia Nsight GPU debugger configuration file
+*.nvuser
+
+# MFractors (Xamarin productivity tool) working folder
+.mfractor/
+
+# Local History for Visual Studio
+.localhistory/
+
+# Visual Studio History (VSHistory) files
+.vshistory/
+
+# BeatPulse healthcheck temp database
+healthchecksdb
+
+# Backup folder for Package Reference Convert tool in Visual Studio 2017
+MigrationBackup/
+
+# Ionide (cross platform F# VS Code tools) working folder
+.ionide/
+
+# Fody - auto-generated XML schema
+FodyWeavers.xsd
+
+# VS Code files for those working on multiple tools
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+*.code-workspace
+
+# Local History for Visual Studio Code
+.history/
+
+# Windows Installer files from build outputs
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# JetBrains Rider
+*.sln.iml


### PR DESCRIPTION
- Revised .gitignore file with updated rules to better ignore build artifacts, temporary files, and IDE-specific files.

- Added .gitattributes to enforce consistent line endings and merge strategies for repository files.
This addresses an issue that occurs when cloning a repository on Windows systems.
Without proper configuration, text files (especially scripts) may use CRLF line endings by default, which can break execution in environments like WSL that require LF endings. This update ensures that scripts and other critical files have the correct LF line endings regardless of the operating system.

- Added .editorconfig to standardize formatting settings across different editors for repository-level files.